### PR TITLE
`CTA main`

### DIFF
--- a/app/components/Sections/MessageTech/index.tsx
+++ b/app/components/Sections/MessageTech/index.tsx
@@ -1,8 +1,10 @@
 import Image from "next/image";
+import clsx from "clsx";
+import Button from "@/components/Button";
 import { assets } from "@/constants/assets";
 import { texts } from "@/constants/texts";
 import useMobileDetect from "@/hooks/useMobileDetected";
-import clsx from "clsx";
+import { externalLink } from "@/constants/messageExternal";
 
 function MessageTech() {
   const isMobile = useMobileDetect();
@@ -10,16 +12,29 @@ function MessageTech() {
   return (
     <div
       className={clsx(
-        'flex items-center max-w-7xl px-8 w-full gap-12',
-        isMobile ? 'flex-col py-10' : 'flex-row py-20', 
+        'flex flex-col items-center max-w-7xl px-8 w-full gap-12',
+        isMobile ? 'py-10' : 'py-20',
       )}
     >
-      <span className="text-subtitle font-medium text-center md:text-start md:text-h3 md:font-bold">
-        {texts.commons.techMessage}
-      </span>
-      <div className="flex w-u296 md:w-[580px] flex-shrink-0">
-        <Image src={assets.illustrationBuild.src} alt={assets.illustrationBuild.alt} className="object-cover" />
+      <div className={clsx('flex w-full items-center gap-12', isMobile ? 'flex-col text-center' : 'flex-row text-start')}>
+        <span className="text-subtitle font-medium md:text-h3 md:font-bold">
+          {texts.commons.techMessage}
+        </span>
+        <div className="flex w-u296 md:w-[580px] flex-shrink-0">
+          <Image src={assets.illustrationBuild.src} alt={assets.illustrationBuild.alt} className="object-cover" />
+        </div>
       </div>
+      {!isMobile && (
+        <div className="flex justify-center w-full py-2">
+          <Button
+            text={texts.actions.requestTrip}
+            icon="WhatsApp"
+            className="w-full max-w-sm"
+            external
+            to={externalLink}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/app/components/Sidebar/index.tsx
+++ b/app/components/Sidebar/index.tsx
@@ -1,28 +1,14 @@
 import clsx from "clsx";
 
-import Button from "../Button";
-import { navbarLinks } from "../../constants/navbarLinks";
-import { texts } from "../../constants/texts";
-import useMobileDetect from "../../hooks/useMobileDetected";
+import Button from "@/components/Button";
+import { externalLink } from "@/constants/messageExternal";
+import { navbarLinks } from "@/constants/navbarLinks";
+import { texts } from "@/constants/texts";
+import useMobileDetect from "@/hooks/useMobileDetected";
 import { ISidebarProps } from "./types";
 
 function Sidebar({ className, handleOnClick }: ISidebarProps) {
   const isMobile = useMobileDetect();
-  
-  const messageOrderExternal = `Hola reparteAR! Quiero realizar un pedido. Los datos son: \n\n
-  - Dirección de salida: \n
-  - Barrio de salida: \n
-  - Dirección de destino: \n
-  - Barrio de destino: \n
-  - Timbre destinatario: \n
-  - Teléfono destinatario: \n
-  - Nombre/apellido destinatario: \n
-  - Franja horaria de entrega: \n
-  - Cantidad de paquetes: \n
-  - Tamaño del paquete: \n
-  - Medida y peso aproximado: \n
-  - Observaciones: \n`
-  const externalLink = `https://wa.me/541164392829?text=${messageOrderExternal}`
 
   return (
     <ul

--- a/app/constants/messageExternal.ts
+++ b/app/constants/messageExternal.ts
@@ -1,0 +1,15 @@
+export const messageExternal = `Hola reparteAR! Quiero realizar un pedido. Los datos son: \n\n
+- Dirección de salida: \n
+- Barrio de salida: \n
+- Dirección de destino: \n
+- Barrio de destino: \n
+- Timbre destinatario: \n
+- Teléfono destinatario: \n
+- Nombre/apellido destinatario: \n
+- Franja horaria de entrega: \n
+- Cantidad de paquetes: \n
+- Tamaño del paquete: \n
+- Medida y peso aproximado: \n
+- Observaciones: \n`;
+
+export const externalLink = `https://wa.me/541164392829?text=${messageExternal}`

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Button from '@/components/Button';
 import Hero from '@/components/Sections/Hero';
 import Navbar from '@/components/Navbar'
 import Services from '@/components/Sections/Services';
@@ -7,8 +8,13 @@ import Testimonials from '@/components/Sections/Testimonials';
 import UsSection from '@/components/Sections/UsSection';
 import SupportSection from '@/components/Sections/SupportSection';
 import Footer from '@/components/Footer/indext';
+import { texts } from '@/constants/texts';
+import { externalLink } from '@/constants/messageExternal';
+import useMobileDetect from './hooks/useMobileDetected';
 
 export default function Home() {
+  const isMobile = useMobileDetect();
+
 
   return (
     <main className="flex flex-col items-center w-full h-auto min-h-screen">
@@ -18,6 +24,17 @@ export default function Home() {
       <Testimonials />
       <UsSection />
       <SupportSection />
+      {isMobile && (
+        <div className="flex justify-center w-full py-2 fixed top-[86%] z-30">
+          <Button
+            text={texts.actions.requestTrip}
+            icon="WhatsApp"
+            className="w-full max-w-sm"
+            external
+            to={externalLink}
+          />
+        </div>
+      )}
       <Footer />
     </main>
   )


### PR DESCRIPTION
# Changes

## Overview

### URLs

- http:localhost:3000/

## Summary tech

### Main changes
- Refactored Home page to CTA main in mobile view
- Refactored MessageTech, and Sidebar components
- Created messageExternal and externalLink constants


## Preview changes
![Captura desde 2023-05-21 17-58-46](https://github.com/leoromero97/reparteAR-landing/assets/57498210/134f1f20-9c5d-448c-83b5-e187531866f7)

